### PR TITLE
🔧 chore: remove push trigger from CI/CD workflow for EC2 deployment

### DIFF
--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -1,9 +1,6 @@
 name: CI/CD to EC2 via ECR
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types:
     - closed


### PR DESCRIPTION
### 변경사항
* 트리거링 두번되는 오류가 생겨 push 트리거는 삭제함